### PR TITLE
Fix bug, width is only available on .image property

### DIFF
--- a/src/ssgi/utils/Utils.js
+++ b/src/ssgi/utils/Utils.js
@@ -81,6 +81,7 @@ export const saveBoneTexture = object => {
 	if (boneTexture && boneTexture.image.width === object.skeleton.boneTexture.image.width) {
 		boneTexture = object.material.uniforms.prevBoneTexture.value
 		boneTexture.image.data.set(object.skeleton.boneTexture.image.data)
+		boneTexture.needsUpdate = true
 	} else {
 		boneTexture?.dispose()
 

--- a/src/ssgi/utils/Utils.js
+++ b/src/ssgi/utils/Utils.js
@@ -78,7 +78,7 @@ export const getMaxMipLevel = texture => {
 export const saveBoneTexture = object => {
 	let boneTexture = object.material.uniforms.prevBoneTexture.value
 
-	if (boneTexture && boneTexture.image.width === object.skeleton.boneTexture.width) {
+	if (boneTexture && boneTexture.image.width === object.skeleton.boneTexture.image.width) {
 		boneTexture = object.material.uniforms.prevBoneTexture.value
 		boneTexture.image.data.set(object.skeleton.boneTexture.image.data)
 	} else {


### PR DESCRIPTION
Currently it seems that you never get into that if (true) branch and the bone texture is always recreated.