### PR TITLE
Make realism-effects independent of currently used Three revision

### DIFF
--- a/src/ssgi/SSGIEffect.js
+++ b/src/ssgi/SSGIEffect.js
@@ -52,7 +52,7 @@ export class SSGIEffect extends Effect {
 			])
 		})
 
-		if (!(camera instanceof PerspectiveCamera)) {
+		if (!camera?.isPerspectiveCamera) {
 			throw new Error(
 				this.constructor.name +
 					" doesn't support cameras of type '" +

--- a/src/ssgi/pass/SSGIPass.js
+++ b/src/ssgi/pass/SSGIPass.js
@@ -176,7 +176,7 @@ export class SSGIPass extends Pass {
 
 				const textureKey = Object.keys(originalMaterial).find(key => {
 					const value = originalMaterial[key]
-					return value instanceof Texture && value.matrix
+					return value?.isTexture && value.matrix
 				})
 
 				if (textureKey) mrtMaterial.uniforms.uvTransform.value = originalMaterial[textureKey].matrix

--- a/src/temporal-reproject/pass/VelocityDepthNormalPass.js
+++ b/src/temporal-reproject/pass/VelocityDepthNormalPass.js
@@ -35,7 +35,7 @@ export class VelocityDepthNormalPass extends Pass {
 	constructor(scene, camera, renderDepth = true) {
 		super("velocityDepthNormalPass")
 
-		if (!(camera instanceof PerspectiveCamera)) {
+		if (!camera?.isPerspectiveCamera) {
 			throw new Error(
 				this.constructor.name +
 					" doesn't support cameras of type '" +


### PR DESCRIPTION
Prevents:

![Screenshot_2023-06-10_at_23 54 37](https://github.com/0beqz/realism-effects/assets/9549760/fd939ffa-6227-44b7-b175-7da89193a0c2)

When importing Three from various sources (regardless the reason, ex. testing latest Three revision while realism dependencies weren't bumped yet.)

* Replace `instanceof` with `.is<Class>` checks