### PR TITLE
fix: ao distance value usage

### DIFF
--- a/src/ao/AOEffect.js
+++ b/src/ao/AOEffect.js
@@ -8,7 +8,6 @@ import { TRAAEffect } from "../traa/TRAAEffect"
 const defaultAOOptions = {
 	resolutionScale: 1,
 	spp: 8,
-	distance: 2,
 	distancePower: 1,
 	power: 2,
 	bias: 40,
@@ -79,6 +78,7 @@ class AOEffect extends Effect {
 
 						case "distance":
 							this.aoPass.fullscreenMaterial.uniforms.aoDistance.value = value
+							this.poissionDenoisePass.fullscreenMaterial.uniforms["distance"].value = Math.max(value, 0.0001)
 							break
 
 						case "resolutionScale":

--- a/src/hbao/shader/hbao.frag
+++ b/src/hbao/shader/hbao.frag
@@ -37,7 +37,7 @@ float getOcclusion(const vec3 cameraPosition, const vec3 worldPos, const vec3 wo
     float deltaDepth = depth - sampleDepth;
 
     // distance based bias
-    float d = distance(sampleWorldPos, cameraPosition);
+    float d = distance(sampleWorldPos, cameraPosition) / aoDistance;
     deltaDepth *= 0.001 * d * d;
 
     float th = thickness * 0.01;

--- a/src/poissionDenoise/PoissionDenoisePass.js
+++ b/src/poissionDenoise/PoissionDenoisePass.js
@@ -26,6 +26,7 @@ const defaultPoissonBlurOptions = {
 	depthPhi: 2,
 	normalPhi: 3.25,
 	samples: 16,
+	distance: 2,
 	normalTexture: null
 }
 
@@ -51,6 +52,7 @@ export class PoissionDenoisePass extends Pass {
 				lumaPhi: { value: 5.0 },
 				depthPhi: { value: 5.0 },
 				normalPhi: { value: 5.0 },
+				distance: { value: 1.0 },
 				resolution: { value: new Vector2() },
 				blueNoiseTexture: { value: null },
 				index: { value: 0 },
@@ -74,7 +76,8 @@ export class PoissionDenoisePass extends Pass {
 		uniforms["cameraMatrixWorld"].value = camera.matrixWorld
 		uniforms["depthPhi"].value = options.depthPhi
 		uniforms["normalPhi"].value = options.normalPhi
-
+		uniforms["distance"].value = options.distance
+		
 		if (options.normalTexture) {
 			uniforms["normalTexture"] = { value : options.normalTexture }
 		} else {

--- a/src/poissionDenoise/shader/poissionDenoise.frag
+++ b/src/poissionDenoise/shader/poissionDenoise.frag
@@ -12,6 +12,7 @@ uniform sampler2D blueNoiseTexture;
 uniform vec2 blueNoiseRepeat;
 uniform int index;
 uniform vec2 resolution;
+uniform float distance;
 
 #include <common>
 #include <sampleBlueNoise>
@@ -105,7 +106,7 @@ void main() {
 #endif
         float lumaSimilarity = max(1.0 - lumaDiff / lumaPhi, 0.0);
 
-        float depthDiff = 1. - distToPlane(worldPos, worldPosSample, normal);
+        float depthDiff = 1. - (distToPlane(worldPos, worldPosSample, normal) / distance);
         float depthSimilarity = max(depthDiff / depthPhi, 0.);
 
         float w = lumaSimilarity * depthSimilarity * normalSimilarity;

--- a/src/ssao/shader/ssao.frag
+++ b/src/ssao/shader/ssao.frag
@@ -115,7 +115,7 @@ void main() {
         float distSample = linearize_depth(sampleDepth, cameraNear, cameraFar);
         float distWorld = linearize_depth(offset.z, cameraNear, cameraFar);
 
-        float rangeCheck = smoothstep(0.0, 1.0, aoDistance / (aoDistance * abs(distSample - distWorld)));
+        float rangeCheck = smoothstep(0.0, 1.0, aoDistance / abs(distSample - distWorld));
         rangeCheck = pow(rangeCheck, distancePower);
         float weight = dot(sampleDirection, normal);
 


### PR DESCRIPTION
fixes #30 

There were issues with the `aoDistance` in both the `ssao` and the `hbao` implementation.
I also move the distance value to the denoiser, as it is needed in the shader there as well.
Then the example from the mentioned issue works as expected.