### PR TITLE
fix: hbao artefacts caused by negative sqrt

### DIFF
--- a/src/hbao/shader/hbao.frag
+++ b/src/hbao/shader/hbao.frag
@@ -53,6 +53,7 @@ float getOcclusion(const vec3 cameraPosition, const vec3 worldPos, const vec3 wo
         float m = max(0., 1. - deltaDepth / th);
         occlusion = 10. * occlusion * m / d;
 
+        occlusion = max(0.0, occlusion);
         occlusion = sqrt(occlusion);
         return occlusion;
     }


### PR DESCRIPTION
Small issue that caused some artefacts. The occlusion value got in some cases below 0 and this cause some noise.