### PR TITLE
fix meshes being visible false, fix noise banding on planes

### DIFF
--- a/src/denoise/pass/DenoiserComposePass.js
+++ b/src/denoise/pass/DenoiserComposePass.js
@@ -70,7 +70,7 @@ export class DenoiserComposePass extends Pass {
 
                 vec3 viewNormal = (vec4(mat.normal, 0.) * cameraMatrixWorld).xyz;
 
-				float viewZ = -getViewZ(depth);
+				float viewZ = getViewZ(depth);
 
                 // view-space position of the current texel
 				vec3 viewPos = getViewPosition(viewZ);

--- a/src/denoise/shader/denoiser_compose_functions.glsl
+++ b/src/denoise/shader/denoiser_compose_functions.glsl
@@ -15,7 +15,7 @@ vec3 getViewPosition(float viewZ) {
   vec4 clipPosition = vec4((vec3(vUv, viewZ) - 0.5) * 2.0, 1.0);
   clipPosition *= clipW;
   vec3 p = (projectionMatrixInverse * clipPosition).xyz;
-  p.z = -viewZ;
+  p.z = viewZ;
   return p;
 }
 

--- a/src/denoise/shader/poisson_denoise.frag
+++ b/src/denoise/shader/poisson_denoise.frag
@@ -166,7 +166,7 @@ void main() {
 
   float roughnessRadius = mix(mat.roughness * mat.roughness, 1., specularPhi);
 
-  float r = flatness * radius * exp(-max(inputs[0].a, inputs[1].a) * 0.01);
+  float r = flatness * radius;
 
   for (int i = 0; i < 8; i++) {
     {

--- a/src/gbuffer/GBufferPass.js
+++ b/src/gbuffer/GBufferPass.js
@@ -93,6 +93,7 @@ export class GBufferPass extends Pass {
 		for (const c of this.visibleMeshes) {
 			const [originalMaterial] = this.cachedMaterials.get(c)
 
+			c.visible = true
 			c.material = originalMaterial
 		}
 	}
@@ -114,7 +115,6 @@ export class GBufferPass extends Pass {
 		// reset state
 		this.lastCameraPosition.copy(this._camera.position)
 		this.lastCameraQuaternion.copy(this._camera.quaternion)
-
 		this._scene.background = background
 	}
 }


### PR DESCRIPTION
- Found that with these newest changes that meshes with depthWrite false were being set to visible: false as the GBufferpass wasn't returning their visible state after running. 
- Found that some changes to getViewPosition and getViewZ in the Denoiser was causing a large band of noise to take up ground planes.

Feel free to just use this as an indicator of these bugs. I don't know if you've managed to test with these issues. Furthermore The SSG/SSR effect isn't super compatible with other effects as it doesn't adhere to the combined effect pipeline system they have in place. The InputColor is completely ignored. I have done modifications locally as well that uses some of the input Color but it breaks the example. But works in all our scenes.